### PR TITLE
don't parse url if it is nil

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
@@ -104,7 +104,7 @@ CGImageRef SVGImageCGImage(UIImage *img)
     {
         SVGKImage *svg = nil;
         
-        if( effectiveSource == nil )
+        if( effectiveSource == nil && imageURL != nil)
             effectiveSource = [SVGKSourceURL sourceFromURL:imageURL];
         
         if( effectiveSource != nil )


### PR DESCRIPTION
In some SVGs the creator can make the misteak to place an object if a href that points to a local path. In this case, the SVGKit crashed.

It should check if the url provided by the href is valid (NSURL pointer is not nil) and therefore try to fetch that url, or just ignore it (the broken image will be shown anyway